### PR TITLE
Hotline splitter update

### DIFF
--- a/Hotline.asl
+++ b/Hotline.asl
@@ -7,6 +7,7 @@ state("HotlineGL", "steam")
 	int showdown_paper :  "HotlineGL.exe", 0xBFFCD8, 0x15CC, 8;
 	int time :            "HotlineGL.exe", 0xBFFCD8, 0x98C, 8;
 	int player_dead :	  "HotlineGL.exe", 0x9F5D78, 0x204, 4, 8;
+	int biker_dead :	  "HotlineGL.exe", 0x9F5D78, 0x204, 4, 8;
 	double player_x :     "HotlineGL.exe", 0x9F5DC0, 4, 0, 8, 8, 0x50;
 	double bike_climb :   "HotlineGL.exe", 0x9F66F4, 4, 0, 8, 8, 0x98;
 
@@ -54,6 +55,7 @@ state("HotlineGL", "gog")
 	int showdown_paper :  "HotlineGL.exe", 0x96BB6C, 8;
 	int time :            "HotlineGL.exe", 0xB75254, 0x984, 8;
 	int player_dead :	  "HotlineGL.exe", 0x96B5CC, 0x204, 4, 8;
+	int biker_dead :	  "HotlineGL.exe", 0x96B2E8, 0x204, 4, 8;
 	double player_x :     "HotlineGL.exe", 0x96B330, 4, 0, 8, 8, 0x50;
 	double bike_climb :   "HotlineGL.exe", 0x96BC64, 4, 4, 8, 8, 0x98;
 
@@ -93,8 +95,38 @@ state("HotlineGL", "gog")
 }
 
 init{
+	ProcessModuleWow64Safe module = modules.Single(x => String.Equals(x.ModuleName, "HotlineGL.exe", StringComparison.OrdinalIgnoreCase));
+	
+	byte[] exe512HashBytes = new byte[0];
+	using (var sha = System.Security.Cryptography.SHA512.Create())
+	{
+		using (var s = File.Open(module.FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+		{
+			exe512HashBytes = sha.ComputeHash(s); 
+		} 
+	}
+    string exeHash = exe512HashBytes.Select(x => x.ToString("X2")).Aggregate((a, b) => a + b);
+
+    //print("init{} - read SHA512-Hash: " + exeHash);
+	
+	switch(exeHash) {
+        case "BD2C5AA66CB09D0B8152740D2B87EF87D74A72C803E6F8A4ECB777EE9086B0018899A8261A85DB06A194DF73A370EC4C5706E68D502E1BD9CEAC3DB12451BAD9":
+            version = "steam";
+            break;
+		case "264F2EB051089A38256CB80C3AB90DD1F29AFF25DDD453F97AD341ACBB3EFC14DE64E56032E905898ABDA1F4E42CB935EF975514F8CC94B27555AEB6B7DD8915":
+            version = "gog";
+            break;
+        default:
+            version = "unsupported";
+			print("This version of Hotline is not supported by the autosplitter. Sorry :(");
+            break;
+    }
+	
+	/*
 	if		(modules.First().ModuleMemorySize == 12718080)	{version = "steam";}
 	else if	(modules.First().ModuleMemorySize == 12140544)	{version = "gog";}
+	else {throw new Exception("triggerInit{} - pointer failed or returned a null. " + "Initialization is not done yet!");}
+	*/
 }
 
 startup
@@ -113,10 +145,7 @@ startup
 		settings.Add("any%_ss", false, "Start/Stop", "any%");
 		settings.SetToolTip("any%_ss", "Just start and end split");
 		settings.Add("any%_parts", false, "Parts", "any%");
-			settings.Add("any%_parts_u", false, "Parts (Urin)", "any%_parts");
-			settings.SetToolTip("any%_parts_u", "Splits in the intro of Tension, Push It, Trauma and after the Part 5 screen");
-			settings.Add("any%_parts_j", false, "Parts (Jack)", "any%_parts");
-			settings.SetToolTip("any%_parts_j", "Splits in the intro of Tension, Push It, Trauma and before the Part 5 screen");
+		settings.SetToolTip("any%_parts", "Splits in the intro of Tension, Push It, Trauma and before the Part 5 screen");
 		settings.Add("any%_lvls", false,  "Levels", "any%");
 		settings.SetToolTip("any%_lvls", "Splits on every Grade, Trauma doors, Showdown picture, and Prankcall bike");
 		settings.Add("any%_floors", false, "Floors", "any%");
@@ -130,7 +159,7 @@ startup
 		
 	settings.Add("igt", false, "Display IGT");
 	settings.SetToolTip("igt", "This setting does nothing, but I hereby inform you that the splitter will ALWAYS track IGT, so you can display it during full game runs by adding a timer that displays Game Time (as opposed to Real Time)");
-  
+	
 	settings.Add("death", false, "Track deaths in IGT");
 	settings.SetToolTip("death", "This setting will track how much time you lost to a death or a level restart and add it to your IGT");
 	
@@ -179,6 +208,12 @@ update
 			vars.traumaSkip = false;
 		}
 	}
+	
+	// startRoom
+	if (settings["IL"] && ( (old.room == current.lvl_intro && current.room != current.lvl_intro) || (old.room == current.biker_intro && current.room != current.biker_intro) ) ) {
+		vars.startRoom = current.room;
+	}
+	
 	//for debugging
 	//if (old.room != current.room) {print(current.room.ToString());}
 }
@@ -188,6 +223,7 @@ start
 	//	start All Levels
 	if (settings["AL"] && current.room == current.main_menu && old.fade == 0 && current.fade == 1 && current.select_index == 0) {
 		vars.afterMetro = false;
+		vars.onLevel = false;
 		vars.deathIGT = 0;
 		vars.maxTime = 0;
 		return true;
@@ -208,8 +244,7 @@ start
 	}
 	
 	//	start ILs
-	if ((settings["IL"])&& current.time > 0){
-		vars.startRoom = current.room;
+	if ((settings["IL"])&& current.time > 0 && vars.startRoom != 0){
 		vars.deathIGT = 0;
 		vars.maxTime = 0;
 		return true;
@@ -220,7 +255,6 @@ reset
 {
 	// reset All Levels - in main menu or on game exit
 	if ((settings["AL"] || !vars.afterMetro) && vars.gameRunning && current.room == current.main_menu && old.room != current.main_menu) {
-		print("hello");
 		return true;
 	}
 	
@@ -232,6 +266,7 @@ reset
 		}
 		//	reset in main menu
 		if (current.room == current.main_menu) {
+			vars.startRoom = 0;
 			return true;
 		}
 	}
@@ -280,12 +315,8 @@ split
 			vars.split3 = false;
 			return true;
 		}
-		//	split Part 4 Urin
-		if (settings["any%_parts_u"] && vars.split4 && old.room == current.part_screen && current.room != current.part_screen) {
-			vars.split4 = false;
-			return true;
-		}// split Part 4 Jack
-		if (settings["any%_parts_j"] && vars.split4 && old.room != current.part_screen && current.room == current.part_screen) {
+		// split Part 4
+		if (vars.split4 && old.room != current.part_screen && current.room == current.part_screen) {
 			vars.split4 = false;
 			return true;
 		}
@@ -338,7 +369,8 @@ split
 	}
 	
 	//	split ILs FULL	//
-	if (settings["IL_level"] && current.room == current.score_screen && old.room != current.score_screen && vars.gameRunning) {
+	if (settings["IL"] && current.room == current.score_screen && old.room != current.score_screen && vars.gameRunning) {
+		vars.startRoom = 0;
 		return true;
 	}
 	//	split IL FLOORS	//
@@ -361,7 +393,7 @@ gameTime
 			vars.maxTime = current.time;
 		}
 		// adding death to IGT
-		if (old.player_dead == 1 && current.player_dead == 0) {
+		if ( (old.player_dead == 1 && current.player_dead == 0) || (old.biker_dead == 1 && current.biker_dead == 0)) {
 			vars.deathIGT += vars.maxTime - current.time;
 			vars.maxTime = current.time;
 		}

--- a/Hotline.asl
+++ b/Hotline.asl
@@ -203,12 +203,8 @@ reset
 		if (current.time == 0) {
 			return true;
 		}
-		//	reset on Trauma 1
-		if (current.room == current.trauma1 && old.room != current.trauma1) {
-			return true;
-		}
 		//	reset in main menu
-		if (current.room > 0 && current.room == current.main_menu && old.room != current.main_menu) {
+		if (current.room > 0 && current.room == current.main_menu) {
 			return true;
 		}
 	}

--- a/Hotline.asl
+++ b/Hotline.asl
@@ -4,14 +4,13 @@ state("HotlineGL", "steam")
 	int menu_state :      "HotlineGL.exe", 0x7EC858, 8, 0x10C, 4, 8;
 	int fade :            "HotlineGL.exe", 0x7EC858, 8, 0x11C, 4, 8;
 	int grade :           "HotlineGL.exe", 0x7EC858, 8, 0x5AC, 4, 8;
-	int showdown_ketchup :"HotlineGL.exe", 0x7EC8B8, 8, 0x7C8, 4, 8;
 	int showdown_paper :  "HotlineGL.exe", 0xBFFCD8, 0x15CC, 8;
 	int time :            "HotlineGL.exe", 0xBFFCD8, 0x98C, 8;
+	int player_dead :	  "HotlineGL.exe", 0x9F5D78, 0x204, 4, 8;		//not used
 	double player_x :     "HotlineGL.exe", 0x9F5DC0, 4, 0, 8, 8, 0x50;
 	double bike_climb :   "HotlineGL.exe", 0x9F66F4, 4, 0, 8, 8, 0x98;
 
 	ushort room :         "HotlineGL.exe", 0xBFFC44, 8;
-	ushort zero :		  "HotlineGL,exe", 0x000000;
 	ushort main_menu :    "HotlineGL.exe", 0x9F7534;
 	ushort ig_menu:		  "HotlineGL.exe", 0x9F7640;
 	ushort lvl_select :   "HotlineGL.exe", 0x9F7660;
@@ -27,10 +26,11 @@ state("HotlineGL", "steam")
 	ushort trauma_outro : "HotlineGL.exe", 0x9F76FC;
 	ushort assault :      "HotlineGL.exe", 0x9F7600;
 	ushort showdown :     "HotlineGL.exe", 0x9F7730;
-	ushort bikerFlat:     "HotlineGL.exe", 0x9F7748;
+	ushort bikerFlat:     "HotlineGL.exe", 0x9F7748;		// not used
 	ushort prankcall :    "HotlineGL.exe", 0x9F7740;
 	ushort resolution :   "HotlineGL.exe", 0x9F7774;
 	ushort scorescreen :  "HotlineGL.exe", 0x9F75A8;
+	ushort gradescreen :  "HotlineGL.exe", 0x9F7728;		// not used
 }
 
 state("HotlineGL", "gog")
@@ -39,14 +39,13 @@ state("HotlineGL", "gog")
 	int menu_state :      "HotlineGL.exe", 0x761E70, 8, 0x10C, 4, 8;
 	int fade :            "HotlineGL.exe", 0x761E70, 8, 0x11C, 4, 8;
 	int grade :           "HotlineGL.exe", 0x761E70, 8, 0x5A8, 4, 8;
-	int showdown_ketchup :"HotlineGL.exe", 0x761E70, 8, 0x7C8, 4, 8;	//don't work//
 	int showdown_paper :  "HotlineGL.exe", 0x96BB6C, 8;
-	int time :            "HotlineGL.exe", 0x96BB6C, 0x98C, 8;			//don't work//	
+	int time :            "HotlineGL.exe", 0x000000;					//don't have this for gog//		// -> this means Game Time and IL setting don't work in GoG version! //
+	int player_dead :	  "HotlineGL.exe", 0x000000;					//not used		//don't have this for gog//
 	double player_x :     "HotlineGL.exe", 0x96B330, 4, 0, 8, 8, 0x50;
 	double bike_climb :   "HotlineGL.exe", 0x96BC64, 4, 4, 8, 8, 0x98;
 
 	ushort room :         "HotlineGL.exe", 0xB751C0, 8;
-	ushort zero :		  "HotlineGL,exe", 0x000000;
 	ushort main_menu :    "HotlineGL.exe", 0x96CA8C;
 	ushort ig_menu:		  "HotlineGL.exe", 0x96CB98;
 	ushort lvl_select :   "HotlineGL.exe", 0x96CBB8;
@@ -62,10 +61,11 @@ state("HotlineGL", "gog")
 	ushort trauma_outro : "HotlineGL.exe", 0x96CC54;
 	ushort assault :      "HotlineGL.exe", 0x96CB58;
 	ushort showdown :     "HotlineGL.exe", 0x96CC88;
-	ushort bikerFlat:     "HotlineGL.exe", 0x96CCA0;
+	ushort bikerFlat:     "HotlineGL.exe", 0x96CCA0;		// not used
 	ushort prankcall :    "HotlineGL.exe", 0x96CC98;
 	ushort resolution :   "HotlineGL.exe", 0x96CCCC;
-	ushort scorescreen :  "HotlineGL.exe", 0x96CB00;	
+	ushort scorescreen :  "HotlineGL.exe", 0x96CB00;
+	ushort gradescreen :  "HotlineGL.exe", 0x9F7728;		//not used		//don't have this for gog//
 }
 
 init{
@@ -90,7 +90,11 @@ startup
 	settings.Add("j_any", false, "any% - Parts (Jack)");
 	settings.SetToolTip("j_any", "Splits in the intro of Tension, Push It, Trauma and before the Part 5 screen");
 	settings.Add("IL", false, "Individual Levels");
-	settings.SetToolTip("IL", "it sorta works - but not withj the GoG version");
+	settings.SetToolTip("IL", "*not supported in GoG version* \nThis starts and stops Real Time and stop Game Time on all levels that have score screens. \nTo display IGT, change your active comparison or your layout to game Time.");
+	settings.Add("igt", false, "Display IGT");
+	settings.SetToolTip("igt", "This setting does nothing, but I hereby inform you that the splitter will ALWAYS track IGT, so you can display it during full game runs by adding a timer that displays Game Time (as opposed to Real Time)");
+	settings.Add("death", false, "Track deaths in IGT");
+	settings.SetToolTip("death", "This setting will track how much time you lost to a death or a level restart and add it to your IGT");	
 	
 	// any%
 	vars.split1 = false;
@@ -102,45 +106,73 @@ startup
 	// All Levels
 	vars.startAL = false;
 	vars.afterMetro = false;
-	// ILs
-	vars.startRoom = 0;
+	// track Death
+	vars.deathIGT = 0;
 }
 
 update
 {
-	// any% splits
-	if (current.room > 0 && current.room == current.decadence) 	{vars.split1 = true;}
-	if (current.room > 0 && current.room == current.neighbors) 	{vars.split2 = true;}
-	if (current.room > 0 && current.room == current.deadline) 	{vars.split3 = true;}
-	if (current.room > 0 && current.room == current.showdown) 	{vars.split4 = true;}
+	//	any%
+	if (current.room > 0) {
+		//	splits
+		if (current.room == current.decadence)	{vars.split1 = true;}
+		if (current.room == current.neighbors) 	{vars.split2 = true;}
+		if (current.room == current.deadline) 	{vars.split3 = true;}
+		if (current.room == current.showdown) 	{vars.split4 = true;}	
+		//	Trauma skip true
+		if ((settings["u_any"] || settings["j_any"] || settings["buffitAny"] || settings["ssAny"]) && 
+				current.room == current.trauma_outro && old.room != current.trauma_outro) {
+			vars.traumaSkip = true;
+		}
+		//	Trauma skip false
+		if (current.room == current.assault && old.room != current.assault) {
+			vars.traumaSkip = false;
+		}
+	}
 	
-	// Trauma skip
-	if ((settings["u_any"] || settings["j_any"] || settings["buffitAny"] || settings["ssAny"]) && 
-			current.room > 0 && current.room == current.trauma_outro && old.room != current.trauma_outro)	{vars.traumaSkip = true;}
-	if (current.room > 0 && current.room == current.assault && old.room != current.assault) 				{vars.traumaSkip = false;}
+	//	after Metro
+	if (current.room == current.grocery_store) {
+		vars.afterMetro = true;
+	}
 	
-	// after Metro
-	if (current.room == current.grocery_store) {vars.afterMetro = true;}
+	//	start variables
+	if (old.fade == 0 && current.fade == 1 && current.select_index == 0) {
+		//	any%
+		if(current.room == current.lvl_select && current.menu_state == 1) {
+			vars.startAny = true;
+			vars.deathIGT = 0;
+		}
+		//	All Levels
+		if (current.room == current.main_menu) {
+			vars.startAL = true;
+			vars.deathIGT = 0;
+		}
+	}
 	
-	// start variables
-	if (old.fade == 0 && current.fade == 1 && current.select_index == 0 && current.room == current.lvl_select && current.menu_state == 1) 	{vars.startAny = true;} // any%
-	if (old.fade == 0 && current.fade == 1 && current.select_index == 0 && current.room == current.main_menu) 								{vars.startAL = true;}  // All Levels
-	
+	//	tracking deaths in gameTime
+	if (settings["death"]) {
+		//	add death to deathIGT
+		if (current.time < old.time) {
+			vars.deathIGT += old.time - current.time;
+		}
+		//	reset deathIGT
+		if (current.time == 0 && old.time != 0 && old.room != current.ig_menu) {
+			vars.deathIGT = 0;
+		}
+	}
 	//for debugging
 	//if (old.room != current.room) {print(current.room.ToString());}
-	
-	
 }
 
 start
 {
-	// start All Levels
-		if ((settings["uj_AL"] || settings["ssAL"] || settings["buffitAL"]) && vars.startAL) {
+	//	start All Levels
+	if ((settings["uj_AL"] || settings["ssAL"] || settings["buffitAL"]) && vars.startAL) {
 		vars.startAL = false;
 		vars.afterMetro = false;
 		return true;
 	}
-	// start any%
+	//	start any%
 	if ((settings["u_any"] || settings["j_any"] || settings["ssAny"] || settings["buffitAny"]) && vars.startAny) {
 		vars.startAny = false;
 		vars.split1 = false;
@@ -151,134 +183,138 @@ start
 		vars.afterMetro = false;
 		return true;
 	}
-	// start ILs
-	if (settings["IL"] && current.time > 0 && current.room != current.trauma1){
-		vars.startRoom = current.room;
-		return true;
-	}
-	//start IL Trauma
-	if (settings["IL"] && current.room == current.trauma1 && old.room != current.trauma1){
+	//	start ILs
+	if (settings["IL"] && current.time > 0){
 		return true;
 	}
 }
 
 reset
 {
-	// (Alt+F4) on game exit - except during Trauma skip
-	//if (current.room == current.zero && !vars.traumaSkip){
-	//	return true;
-	//}
-	// All Levels / ILs - reset in main menu or on game exit
-	if ((settings["uj_AL"] || settings["ssAL"] || settings["buffitAL"] || settings["IL"] || !vars.afterMetro) && 
-			current.room > 0 && current.room == current.main_menu && old.room != current.main_menu){
+	// reset All Levels - in main menu or on game exit
+	if ((settings["uj_AL"] || settings["ssAL"] || settings["buffitAL"] || !vars.afterMetro) && 
+			current.room > 0 && current.room == current.main_menu && old.room != current.main_menu) {
 		return true;
 	}
-	// ILs - reset when respawning to the first screen
-	if (settings["IL"] &&
-			current.room == vars.startRoom && current.time == 0){
-		return true;
-	}
-	// ILs - reset on Trauma 1
-	if (settings["IL"] && 
-			current.room == current.trauma1 && old.room != current.trauma1){
-		return true;
+	
+	// reset ILs	//
+	if (settings["IL"]){
+		//	reset when respawning to the first screen
+		if (current.time == 0) {
+			return true;
+		}
+		//	reset on Trauma 1
+		if (current.room == current.trauma1 && old.room != current.trauma1) {
+			return true;
+		}
+		//	reset in main menu
+		if (current.room > 0 && current.room == current.main_menu && old.room != current.main_menu) {
+			return true;
+		}
 	}
 }
 
 exit
 {
-	//Reset on game exit escept during Trauma Skip
-	if (!vars.traumaSkip){
+	//	Reset on game exit escept during Trauma Skip
+	if (!vars.traumaSkip) {
 		new TimerModel() { CurrentState = timer }.Reset();
 	}
 }
 
 split
 {	
-	// end split
-	if ((current.room == current.resolution && old.bike_climb <= 0.30 && current.bike_climb > 0.30)){
+	//	end split (for every cat and Resolution IL)
+	if ((current.room == current.resolution && old.bike_climb <= 0.30 && current.bike_climb > 0.30)) {
 		return true;
 	}
 	
-	// All Levels Urin/Jack - split Parts
-	if (settings["uj_AL"] &&
+	//	split All Levels Urin/Jack - split at the end of Part screens
+	if (settings["uj_AL"]  && current.room > 0 &&
 			vars.afterMetro == true && old.room == current.part_screen && current.room != current.part_screen) {
 		return true;
 	}
 	
-	//		any% URIN/JACK		//
-	// split part 1
-	if ((settings["u_any"] || settings["j_any"]) && 
-			(vars.split1 && old.room != current.lvl_intro && current.room == current.lvl_intro)) {
-		vars.split1 = false;
-		return true;
-	}
-	// split part 2
-	if ((settings["u_any"] || settings["j_any"]) && 
-			(vars.split2 && old.room != current.lvl_intro && current.room == current.lvl_intro)) {
-		vars.split2 = false;
-		return true;
-	}
-	// split part 3
-	if ((settings["u_any"] || settings["j_any"]) && 
-			(vars.split3 && old.room != current.trauma_intro && current.room == current.trauma_intro)) {
-		vars.split3 = false;
-		return true;
-	}
-	// Urin - split part 4
-	if (settings["u_any"] && 
-			(vars.split4 && old.room == current.part_screen && current.room != current.part_screen)) {
-		vars.split4 = false;
-		return true;
-	}
-	// Jack - split part 4
-	if (settings["j_any"] && 
-			(vars.split4 && old.room != current.part_screen && current.room == current.part_screen)) {
-		vars.split4 = false;
-		return true;
+	//	split any% URIN	//
+	if (settings["u_any"] && current.room > 0) {
+		//	split Part 1
+		if (vars.split1 && old.room != current.lvl_intro && current.room == current.lvl_intro) {
+			vars.split1 = false;
+			return true;
+		}
+		//	split Part 2
+		if (vars.split2 && old.room != current.lvl_intro && current.room == current.lvl_intro) {
+			vars.split2 = false;
+			return true;
+		}
+		//	split Part 3
+		if (vars.split3 && old.room != current.trauma_intro && current.room == current.trauma_intro) {
+			vars.split3 = false;
+			return true;
+		}
+		//	split Part 4
+		if (vars.split4 && old.room == current.part_screen && current.room != current.part_screen) {
+			vars.split4 = false;
+			return true;
+		}
 	}
 	
-	//		BUFFIT  	//
-	// Grades
-	if ((settings["buffitAL"] || settings["buffitAny"]) &&
-			(old.grade == 0 && current.grade == 1)){
-		return true;
-	}
-	// Trauma door
-	if ((settings["buffitAL"] || settings["buffitAny"]) &&
-			(current.room == current.trauma2 && old.player_x >= -32 && current.player_x < -32)){
-		return true;
-	}
-	// Showdown Photo
-	if ((settings["buffitAL"] || settings["buffitAny"]) &&
-			(current.room == current.showdown && old.showdown_paper == 0 && current.showdown_paper == 1)){
-		return true;
-	}
-	// Prankcall Bike
-	if ((settings["buffitAL"] || settings["buffitAny"]) &&
-			(current.room == current.prankcall && old.bike_climb <= 0.30 && current.bike_climb > 0.30)){
-		return true;
+	//	split any% JACK	//
+	if (settings["j_any"] && current.room > 0) {
+		// Part 1
+		if (vars.split1 && old.room != current.lvl_intro && current.room == current.lvl_intro) {
+			vars.split1 = false;
+			return true;
+		}
+		// Part 2
+		if (vars.split2 && old.room != current.lvl_intro && current.room == current.lvl_intro) {
+			vars.split2 = false;
+			return true;
+		}
+		// Part 3
+		if (vars.split3 && old.room != current.trauma_intro && current.room == current.trauma_intro) {
+			vars.split3 = false;
+			return true;
+		}
+		// Part 4
+		if (vars.split4 && old.room != current.part_screen && current.room == current.part_screen) {
+			vars.split4 = false;
+			return true;
+		}
 	}
 	
-	//		INDIVIDUAL LEVELS		//
-	// ILs
-	if (settings["IL"] && 
-			old.room != current.scorescreen && current.room == current.scorescreen){
+	//	split BUFFIT  //
+	if ((settings["buffitAL"] || settings["buffitAny"]) && current.room > 0) {
+		//	Grades
+		if (old.grade == 0 && current.grade == 1){
+			return true;
+		}
+		//	Trauma door
+		if (current.room == current.trauma2 && old.player_x >= -32 && current.player_x < -32) {
+			return true;
+		}
+		//	Showdown Photo
+		if (current.room == current.showdown && old.showdown_paper == 0 && current.showdown_paper == 1) {
+			return true;
+		}
+		//	Prankcall Bike
+		if (current.room == current.prankcall && old.bike_climb <= 0.30 && current.bike_climb > 0.30) {
+			return true;
+		}
+	}
+	
+	//	split Ils
+	if (settings["IL"] && current.room == current.scorescreen && old.room != current.scorescreen && current.room > 0) {
 		return true;
 	}
-	// IL - Trauma
-	if (settings["IL"] && 
-			old.room == current.trauma2 && current.room != current.trauma2){
-		return true;
-	}
-	// IL - Showdown
-	if (settings["IL"] && 
-			old.room == current.showdown && current.room != current.showdown){
-		return true;
-	}
-	// IL - Prankcall
-	if (settings["IL"] && 
-			old.room != current.bikerFlat && current.room == current.bikerFlat){
-		return true;
-	}
+}
+
+isLoading
+{
+	return true;
+}
+
+gameTime
+{
+	return TimeSpan.FromMilliseconds(Convert.ToInt32((current.time+vars.deathIGT)*1000/60));
 }

--- a/Hotline.asl
+++ b/Hotline.asl
@@ -6,31 +6,43 @@ state("HotlineGL", "steam")
 	int grade :           "HotlineGL.exe", 0x7EC858, 8, 0x5AC, 4, 8;
 	int showdown_paper :  "HotlineGL.exe", 0xBFFCD8, 0x15CC, 8;
 	int time :            "HotlineGL.exe", 0xBFFCD8, 0x98C, 8;
-	//int player_dead :	  "HotlineGL.exe", 0x9F5D78, 0x204, 4, 8;		//not used
+	int player_dead :	  "HotlineGL.exe", 0x9F5D78, 0x204, 4, 8;
 	double player_x :     "HotlineGL.exe", 0x9F5DC0, 4, 0, 8, 8, 0x50;
 	double bike_climb :   "HotlineGL.exe", 0x9F66F4, 4, 0, 8, 8, 0x98;
 
+	
 	ushort room :         "HotlineGL.exe", 0xBFFC44, 8;
+	
 	ushort main_menu :    "HotlineGL.exe", 0x9F7534;
 	ushort ig_menu:		  "HotlineGL.exe", 0x9F7640;
 	ushort lvl_select :   "HotlineGL.exe", 0x9F7660;
 	ushort lvl_intro :    "HotlineGL.exe", 0x9F7578;
+	ushort biker_intro :  "HotlineGL.exe", 0x9F77A0;
 	ushort part_screen :  "HotlineGL.exe", 0x9F75E0;
+	ushort score_screen : "HotlineGL.exe", 0x9F75A8;
+	ushort grade_screen : "HotlineGL.exe", 0x9F7728;
 	ushort grocery_store :"HotlineGL.exe", 0x9F7674;
-	ushort decadence :    "HotlineGL.exe", 0x9F7584;
-	ushort neighbors :    "HotlineGL.exe", 0x9F7670;
-	ushort deadline :     "HotlineGL.exe", 0x9F75E4;
+	ushort biker_flat:    "HotlineGL.exe", 0x9F7748;
+	
+	ushort decadence1 :   "HotlineGL.exe", 0x9F7584;
+	ushort neighbors1 :	  "HotlineGL.exe", 0x9F7638;
+	ushort neighbors4 :	  "HotlineGL.exe", 0x9F762C;
+	ushort neighbors5 :   "HotlineGL.exe", 0x9F7670;
+	ushort biker_fight :  "HotlineGL.exe", 0x9F7668;
+	ushort deadline1 :    "HotlineGL.exe", 0x9F75E4;
 	ushort trauma_intro : "HotlineGL.exe", 0x9F7700;
+	ushort trauma0 :	  "HotlineGL.exe", 0x9F76A0;
 	ushort trauma1:		  "HotlineGL.exe", 0x9F7698;
 	ushort trauma2 :      "HotlineGL.exe", 0x9F769C;
 	ushort trauma_outro : "HotlineGL.exe", 0x9F76FC;
-	ushort assault :      "HotlineGL.exe", 0x9F7600;
-	ushort showdown :     "HotlineGL.exe", 0x9F7730;
-	//ushort bikerFlat:     "HotlineGL.exe", 0x9F7748;		// not used
+	ushort assault1 :     "HotlineGL.exe", 0x9F7600;
+	ushort vengeance1 :   "HotlineGL.exe", 0x9F7770;
+	ushort vengeance3 :   "HotlineGL.exe", 0x9F7624;
+	ushort showdown3 :    "HotlineGL.exe", 0x9F7730;
 	ushort prankcall :    "HotlineGL.exe", 0x9F7740;
-	ushort resolution :   "HotlineGL.exe", 0x9F7774;
-	ushort scorescreen :  "HotlineGL.exe", 0x9F75A8;
-	//ushort gradescreen :  "HotlineGL.exe", 0x9F7728;		// not used
+	ushort jacket_fight : "HotlineGL.exe", 0x9F7744;
+	ushort resolution1 :  "HotlineGL.exe", 0x9F7774;
+	ushort resolution2 :  "HotlineGL.exe", 0x9F7794;
 }
 
 state("HotlineGL", "gog")
@@ -40,32 +52,44 @@ state("HotlineGL", "gog")
 	int fade :            "HotlineGL.exe", 0x761E70, 8, 0x11C, 4, 8;
 	int grade :           "HotlineGL.exe", 0x761E70, 8, 0x5A8, 4, 8;
 	int showdown_paper :  "HotlineGL.exe", 0x96BB6C, 8;
-	int time :            "HotlineGL.exe", 0x000000;					//don't have this for gog//		// -> this means Game Time and IL setting don't work in GoG version! //
-	int player_dead :	  "HotlineGL.exe", 0x000000;					//not used		//don't have this for gog//
+	int time :            "HotlineGL.exe", 0xB75254, 0x984, 8;
+	int player_dead :	  "HotlineGL.exe", 0x96B5CC, 0x204, 4, 8;
 	double player_x :     "HotlineGL.exe", 0x96B330, 4, 0, 8, 8, 0x50;
 	double bike_climb :   "HotlineGL.exe", 0x96BC64, 4, 4, 8, 8, 0x98;
 
+	
 	ushort room :         "HotlineGL.exe", 0xB751C0, 8;
+	
 	ushort main_menu :    "HotlineGL.exe", 0x96CA8C;
 	ushort ig_menu:		  "HotlineGL.exe", 0x96CB98;
 	ushort lvl_select :   "HotlineGL.exe", 0x96CBB8;
 	ushort lvl_intro :    "HotlineGL.exe", 0x96CAD0;
+	ushort biker_intro :  "HotlineGL.exe", 0x96CCF8;
 	ushort part_screen :  "HotlineGL.exe", 0x96CB38;
+	ushort score_screen : "HotlineGL.exe", 0x96CB00;
+	ushort grade_screen : "HotlineGL.exe", 0x96CC80;
 	ushort grocery_store :"HotlineGL.exe", 0x96CBCC;
-	ushort decadence :    "HotlineGL.exe", 0x96CADC;
-	ushort neighbors :    "HotlineGL.exe", 0x96CBC8;
-	ushort deadline :     "HotlineGL.exe", 0x96CB3C;
+	ushort biker_flat:    "HotlineGL.exe", 0x96CCA0;
+	
+	ushort decadence1 :   "HotlineGL.exe", 0x96CADC;
+	ushort neighbors1 :	  "HotlineGL.exe", 0x96CB90;
+	ushort neighbors4 :	  "HotlineGL.exe", 0x96CB84;
+	ushort neighbors5 :   "HotlineGL.exe", 0x96CBC8;
+	ushort biker_fight :  "HotlineGL.exe", 0x96CBC0;
+	ushort deadline1 :    "HotlineGL.exe", 0x96CB3C;
 	ushort trauma_intro : "HotlineGL.exe", 0x96CC58;
+	ushort trauma0 :	  "HotlineGL.exe", 0x96CBF8;
 	ushort trauma1:		  "HotlineGL.exe", 0x96CBF0;
 	ushort trauma2 :      "HotlineGL.exe", 0x96CBF4;
 	ushort trauma_outro : "HotlineGL.exe", 0x96CC54;
-	ushort assault :      "HotlineGL.exe", 0x96CB58;
-	ushort showdown :     "HotlineGL.exe", 0x96CC88;
-	//ushort bikerFlat:     "HotlineGL.exe", 0x96CCA0;		// not used
+	ushort assault1 :     "HotlineGL.exe", 0x96CB58;
+	ushort vengeance1 :   "HotlineGL.exe", 0x96CCC8;
+	ushort vengeance3 :   "HotlineGL.exe", 0x96CB7C;
+	ushort showdown3 :    "HotlineGL.exe", 0x96CC88;
 	ushort prankcall :    "HotlineGL.exe", 0x96CC98;
-	ushort resolution :   "HotlineGL.exe", 0x96CCCC;
-	ushort scorescreen :  "HotlineGL.exe", 0x96CB00;
-	//ushort gradescreen :  "HotlineGL.exe", 0x9F7728;		//not used		//don't have this for gog//
+	ushort jacket_fight : "HotlineGL.exe", 0x96CC9C;
+	ushort resolution1 :  "HotlineGL.exe", 0x96CCCC;
+	ushort resolution2 :  "HotlineGL.exe", 0x96CCEC;
 }
 
 init{
@@ -75,73 +99,84 @@ init{
 
 startup
 {
-	settings.Add("ssAL", false, "All Levels - Start/Stop");
-	settings.SetToolTip("ssAL", "Just start and end split");
-	settings.Add("buffitAL", false,  "All Levels - Every Level (Buffet) (use this)");
-	settings.SetToolTip("buffitAL", "Splits on every Grade, Trauma doors, Showdown picture, and Prankcall bike");
-	settings.Add("uj_AL", false, "All Levels - Parts (Urin/Jack)");
-	settings.SetToolTip("uj_AL", "Splits after \"Part X\" screens (except part 1)");
-	settings.Add("ssAny", false, "any% - Start/Stop");
-	settings.SetToolTip("ssAny", "Just start and end split");
-	settings.Add("buffitAny", false,  "any% - Every Level (Buffet) (use this)");
-	settings.SetToolTip("buffitAny", "Splits on every Grade, Trauma doors, Showdown picture, and Prankcall bike");
-	settings.Add("u_any", false, "any% - Parts (Urin)");
-	settings.SetToolTip("u_any", "Splits in the intro of Tension, Push It, Trauma and after the Part 5 screen");
-	settings.Add("j_any", false, "any% - Parts (Jack)");
-	settings.SetToolTip("j_any", "Splits in the intro of Tension, Push It, Trauma and before the Part 5 screen");
+	settings.Add("AL", false, "All Levels");
+		settings.Add("AL_ss", false, "Start/Stop", "AL");
+		settings.SetToolTip("AL_ss", "Just start and end split");
+		settings.Add("AL_parts", false, "Parts", "AL");
+		settings.SetToolTip("AL_parts", "Splits after \"Part X\" screens (except part 1)");
+		settings.Add("AL_lvls", false,  "Levels", "AL");
+		settings.SetToolTip("AL_lvls", "Splits on every Grade, Trauma doors, Showdown picture, and Prankcall bike");
+		settings.Add("AL_floors", false, "Floors", "AL");
+		settings.SetToolTip("AL_floors", "Splits every floor of every level");
+		
+	settings.Add("any%", false, "any%");
+		settings.Add("any%_ss", false, "Start/Stop", "any%");
+		settings.SetToolTip("any%_ss", "Just start and end split");
+		settings.Add("any%_parts", false, "Parts", "any%");
+			settings.Add("any%_parts_u", false, "Parts (Urin)", "any%_parts");
+			settings.SetToolTip("any%_parts_u", "Splits in the intro of Tension, Push It, Trauma and after the Part 5 screen");
+			settings.Add("any%_parts_j", false, "Parts (Jack)", "any%_parts");
+			settings.SetToolTip("any%_parts_j", "Splits in the intro of Tension, Push It, Trauma and before the Part 5 screen");
+		settings.Add("any%_lvls", false,  "Levels", "any%");
+		settings.SetToolTip("any%_lvls", "Splits on every Grade, Trauma doors, Showdown picture, and Prankcall bike");
+		settings.Add("any%_floors", false, "Floors", "any%");
+		settings.SetToolTip("any%_floors", "Splits every floor of every level");
+		
 	settings.Add("IL", false, "Individual Levels");
-	settings.SetToolTip("IL", "*not supported in GoG version* \nThis starts and stops Real Time and stop Game Time on all levels that have score screens. \nTo display IGT, change your active comparison or your layout to game Time.");
+		settings.Add("IL_level", false, "Full Level", "IL");
+		settings.SetToolTip("IL_level", "This starts and stops Real Time and stop Game Time on all levels that have score screens. \nTo display IGT, change your active comparison or your layout to game Time.");
+		settings.Add("IL_floor", false, "Floors", "IL");
+		settings.SetToolTip("IL_floor", "Like Individual Levels setting, but splits on every screen transition.");
+		
 	settings.Add("igt", false, "Display IGT");
 	settings.SetToolTip("igt", "This setting does nothing, but I hereby inform you that the splitter will ALWAYS track IGT, so you can display it during full game runs by adding a timer that displays Game Time (as opposed to Real Time)");
+	
+	settings.Add("death", false, "Track deaths in IGT");
+	settings.SetToolTip("death", "This setting will track how much time you lost to a death or a level restart and add it to your IGT");
 	
 	// any%
 	vars.split1 = false;
 	vars.split2 = false;
 	vars.split3 = false;
 	vars.split4 = false;
-	vars.startAny = false;
 	vars.traumaSkip = false;
 	// All Levels
-	vars.startAL = false;
 	vars.afterMetro = false;
+	// ILs
+	vars.startRoom = 0;
+	// track Death
+	vars.deathIGT = 0;
+	vars.maxTime = 0;
+	// split floors
+	vars.onLevel = false;
+	// game Running				// when the game is being closed, all pointers point to 0 and every comparison becomes true and causes false splits and other bullshit
+	vars.gameRunning = false;	
 }
 
 update
 {
-	//	any%
+	// vars.gameRunning
 	if (current.room > 0) {
-		//	splits
-		if (current.room == current.decadence)	{vars.split1 = true;}
-		if (current.room == current.neighbors) 	{vars.split2 = true;}
-		if (current.room == current.deadline) 	{vars.split3 = true;}
-		if (current.room == current.showdown) 	{vars.split4 = true;}	
-		//	Trauma skip true
-		if ((settings["u_any"] || settings["j_any"] || settings["buffitAny"] || settings["ssAny"]) && 
-				current.room == current.trauma_outro && old.room != current.trauma_outro) {
-			vars.traumaSkip = true;
-		}
-		//	Trauma skip false
-		if (current.room == current.assault && old.room != current.assault) {
-			vars.traumaSkip = false;
-		}
+		vars.gameRunning = true;
 	}
+	else {
+		vars.gameRunning = false;
+	}	
 	
 	//	after Metro
 	if (current.room == current.grocery_store) {
 		vars.afterMetro = true;
 	}
 	
-	//	start variables
-	if (old.fade == 0 && current.fade == 1 && current.select_index == 0) {
-		//	any%
-		if(current.room == current.lvl_select && current.menu_state == 1) {
-			vars.startAny = true;
-			vars.deathIGT = 0;
+	//	Trauma Skip
+	if (settings["any%"] && vars.gameRunning) {
+		//	Trauma skip true
+		if (current.room == current.trauma_outro && old.room != current.trauma_outro) {
+			vars.traumaSkip = true;
 		}
-		//	All Levels
-		if (current.room == current.main_menu) {
-			vars.startAL = true;
-			vars.deathIGT = 0;
+		//	Trauma skip false
+		if (current.room == current.assault1 && old.room != current.assault1) {
+			vars.traumaSkip = false;
 		}
 	}
 	//for debugging
@@ -151,24 +186,32 @@ update
 start
 {
 	//	start All Levels
-	if ((settings["uj_AL"] || settings["ssAL"] || settings["buffitAL"]) && vars.startAL) {
-		vars.startAL = false;
+	if (settings["AL"] && current.room == current.main_menu && old.fade == 0 && current.fade == 1 && current.select_index == 0) {
 		vars.afterMetro = false;
+		vars.deathIGT = 0;
+		vars.maxTime = 0;
 		return true;
 	}
+	
 	//	start any%
-	if ((settings["u_any"] || settings["j_any"] || settings["ssAny"] || settings["buffitAny"]) && vars.startAny) {
-		vars.startAny = false;
+	if (settings["any%"] && current.room == current.lvl_select && current.menu_state == 1 && old.fade == 0 && current.fade == 1 && current.select_index == 0) {
 		vars.split1 = false;
 		vars.split2 = false;
 		vars.split3 = false;
 		vars.split4 = false;
 		vars.traumaSkip = false;
 		vars.afterMetro = false;
+		vars.onLevel = false;
+		vars.deathIGT = 0;
+		vars.maxTime = 0;
 		return true;
 	}
+	
 	//	start ILs
-	if (settings["IL"] && current.time > 0){
+	if ((settings["IL"])&& current.time > 0){
+		vars.startRoom = current.room;
+		vars.deathIGT = 0;
+		vars.maxTime = 0;
 		return true;
 	}
 }
@@ -176,19 +219,19 @@ start
 reset
 {
 	// reset All Levels - in main menu or on game exit
-	if ((settings["uj_AL"] || settings["ssAL"] || settings["buffitAL"] || !vars.afterMetro) && 
-			current.room > 0 && current.room == current.main_menu && old.room != current.main_menu) {
+	if ((settings["AL"] || !vars.afterMetro) && vars.gameRunning && current.room == current.main_menu && old.room != current.main_menu) {
+		print("hello");
 		return true;
 	}
 	
 	// reset ILs	//
-	if (settings["IL"]){
+	if (settings["IL"] && vars.gameRunning){
 		//	reset when respawning to the first screen
-		if (current.time == 0) {
+		if (current.time == 0 && current.room == vars.startRoom) {
 			return true;
 		}
 		//	reset in main menu
-		if (current.room > 0 && current.room == current.main_menu) {
+		if (current.room == current.main_menu) {
 			return true;
 		}
 	}
@@ -196,8 +239,8 @@ reset
 
 exit
 {
-	//	Reset on game exit escept during Trauma Skip
-	if (!vars.traumaSkip && settings.ResetEnabled) {
+	//	Reset on game exit except during Trauma Skip
+	if (!vars.traumaSkip && settings.ResetEnabled && timer.CurrentPhase != TimerPhase.Ended) {
 		new TimerModel() { CurrentState = timer }.Reset();
 	}
 }
@@ -205,18 +248,23 @@ exit
 split
 {	
 	//	end split (for every cat and Resolution IL)
-	if ((current.room == current.resolution && old.bike_climb <= 0.30 && current.bike_climb > 0.30)) {
+	if ((current.room == current.resolution1 && old.bike_climb <= 0.30 && current.bike_climb > 0.30)) {
 		return true;
 	}
 	
-	//	split All Levels Urin/Jack - split at the end of Part screens
-	if (settings["uj_AL"]  && current.room > 0 &&
+	//	split All Levels PARTS Urin/Jack - split at the end of Part screens
+	if (settings["AL_parts"]  && vars.gameRunning &&
 			vars.afterMetro == true && old.room == current.part_screen && current.room != current.part_screen) {
 		return true;
 	}
 	
-	//	split any% URIN	//
-	if (settings["u_any"] && current.room > 0) {
+	//	split any% PARTS Urin	//
+	if (settings["any%_parts"] && vars.gameRunning) {
+		//	identify end of part
+		if (current.room == current.decadence1)	{vars.split1 = true;}
+		if (current.room == current.neighbors5) {vars.split2 = true;}
+		if (current.room == current.deadline1) 	{vars.split3 = true;}
+		if (current.room == current.showdown3) 	{vars.split4 = true;}	
 		//	split Part 1
 		if (vars.split1 && old.room != current.lvl_intro && current.room == current.lvl_intro) {
 			vars.split1 = false;
@@ -232,39 +280,19 @@ split
 			vars.split3 = false;
 			return true;
 		}
-		//	split Part 4
-		if (vars.split4 && old.room == current.part_screen && current.room != current.part_screen) {
+		//	split Part 4 Urin
+		if (settings["any%_parts_u"] && vars.split4 && old.room == current.part_screen && current.room != current.part_screen) {
+			vars.split4 = false;
+			return true;
+		}// split Part 4 Jack
+		if (settings["any%_parts_j"] && vars.split4 && old.room != current.part_screen && current.room == current.part_screen) {
 			vars.split4 = false;
 			return true;
 		}
 	}
 	
-	//	split any% JACK	//
-	if (settings["j_any"] && current.room > 0) {
-		// Part 1
-		if (vars.split1 && old.room != current.lvl_intro && current.room == current.lvl_intro) {
-			vars.split1 = false;
-			return true;
-		}
-		// Part 2
-		if (vars.split2 && old.room != current.lvl_intro && current.room == current.lvl_intro) {
-			vars.split2 = false;
-			return true;
-		}
-		// Part 3
-		if (vars.split3 && old.room != current.trauma_intro && current.room == current.trauma_intro) {
-			vars.split3 = false;
-			return true;
-		}
-		// Part 4
-		if (vars.split4 && old.room != current.part_screen && current.room == current.part_screen) {
-			vars.split4 = false;
-			return true;
-		}
-	}
-	
-	//	split BUFFIT  //
-	if ((settings["buffitAL"] || settings["buffitAny"]) && current.room > 0) {
+	//	split LEVELS  any%/AL	//
+	if ((settings["AL_lvls"] || settings["any%_lvls"]) && vars.gameRunning) {
 		//	Grades
 		if (old.grade == 0 && current.grade == 1){
 			return true;
@@ -274,7 +302,7 @@ split
 			return true;
 		}
 		//	Showdown Photo
-		if (current.room == current.showdown && old.showdown_paper == 0 && current.showdown_paper == 1) {
+		if (current.room == current.showdown3 && old.showdown_paper == 0 && current.showdown_paper == 1) {
 			return true;
 		}
 		//	Prankcall Bike
@@ -283,8 +311,38 @@ split
 		}
 	}
 	
-	//	split Ils
-	if (settings["IL"] && current.room == current.scorescreen && old.room != current.scorescreen && current.room > 0) {
+	//	split FLOORS any%/AL	//
+	if ((settings["any%_floors"] || settings["AL_floors"]) && vars.gameRunning) {
+		//	Showdown Photo + Neighbors 4 + Vengeance 3
+		if (current.room == current.showdown3 && old.showdown_paper == 0 && current.showdown_paper == 1				
+				|| (current.room != current.neighbors4 && old.room == current.neighbors4 && old.room != current.ig_menu)
+				|| (current.room != current.vengeance3 && old.room == current.vengeance3 && old.room != current.ig_menu) ) {
+			vars.onLevel = false;
+			return true;
+		}
+		// split new floor except Phon Hom and IG Menu
+		if(vars.onLevel == true && old.room != current.room
+				&& !(current.room == current.ig_menu || old.room == current.ig_menu) 
+				&& !(current.room == current.biker_fight || old.room == current.biker_fight) 
+				&& !(current.room == current.jacket_fight || old.room == current.jacket_fight) ) {
+			return true;
+		}
+		// set onLevel = true in Intro and some other places
+		if(current.room == current.lvl_intro || current.room == current.trauma0 || current.room == current.biker_intro || current.room == current.vengeance1 || current.room == current.neighbors1) {
+			vars.onLevel = true;
+		}
+		// set onLevel = false in Score Screen and some other places
+		if(current.room == current.score_screen || current.room == current.biker_flat || current.room == current.trauma_outro || current.room == current.resolution2){
+			vars.onLevel = false;
+		}
+	}
+	
+	//	split ILs FULL	//
+	if (settings["IL_level"] && current.room == current.score_screen && old.room != current.score_screen && vars.gameRunning) {
+		return true;
+	}
+	//	split IL FLOORS	//
+	if (settings["IL_floor"] && old.room != current.room && current.room != current.ig_menu && old.room != current.ig_menu && vars.gameRunning) {
 		return true;
 	}
 }
@@ -296,5 +354,23 @@ isLoading
 
 gameTime
 {
-	return TimeSpan.FromMilliseconds(Convert.ToInt32((current.time)*1000/60));
+	// Tracking deaths in IGT
+	if (settings["death"]){
+		//update maxTime
+		if (current.time > vars.maxTime) {
+			vars.maxTime = current.time;
+		}
+		// adding death to IGT
+		if (old.player_dead == 1 && current.player_dead == 0) {
+			vars.deathIGT += vars.maxTime - current.time;
+			vars.maxTime = current.time;
+		}
+		// clear death and maxTime at score screen
+		if (current.room != current.grade_screen && old.room == current.grade_screen) {
+			vars.deathIGT = 0;
+			vars.maxTime = 0;
+		}
+	}
+	
+	return TimeSpan.FromMilliseconds(Convert.ToInt32((current.time + vars.deathIGT)*1000/60));
 }

--- a/Hotline.asl
+++ b/Hotline.asl
@@ -6,7 +6,7 @@ state("HotlineGL", "steam")
 	int grade :           "HotlineGL.exe", 0x7EC858, 8, 0x5AC, 4, 8;
 	int showdown_paper :  "HotlineGL.exe", 0xBFFCD8, 0x15CC, 8;
 	int time :            "HotlineGL.exe", 0xBFFCD8, 0x98C, 8;
-	int player_dead :	  "HotlineGL.exe", 0x9F5D78, 0x204, 4, 8;		//not used
+	//int player_dead :	  "HotlineGL.exe", 0x9F5D78, 0x204, 4, 8;		//not used
 	double player_x :     "HotlineGL.exe", 0x9F5DC0, 4, 0, 8, 8, 0x50;
 	double bike_climb :   "HotlineGL.exe", 0x9F66F4, 4, 0, 8, 8, 0x98;
 
@@ -26,11 +26,11 @@ state("HotlineGL", "steam")
 	ushort trauma_outro : "HotlineGL.exe", 0x9F76FC;
 	ushort assault :      "HotlineGL.exe", 0x9F7600;
 	ushort showdown :     "HotlineGL.exe", 0x9F7730;
-	ushort bikerFlat:     "HotlineGL.exe", 0x9F7748;		// not used
+	//ushort bikerFlat:     "HotlineGL.exe", 0x9F7748;		// not used
 	ushort prankcall :    "HotlineGL.exe", 0x9F7740;
 	ushort resolution :   "HotlineGL.exe", 0x9F7774;
 	ushort scorescreen :  "HotlineGL.exe", 0x9F75A8;
-	ushort gradescreen :  "HotlineGL.exe", 0x9F7728;		// not used
+	//ushort gradescreen :  "HotlineGL.exe", 0x9F7728;		// not used
 }
 
 state("HotlineGL", "gog")
@@ -61,11 +61,11 @@ state("HotlineGL", "gog")
 	ushort trauma_outro : "HotlineGL.exe", 0x96CC54;
 	ushort assault :      "HotlineGL.exe", 0x96CB58;
 	ushort showdown :     "HotlineGL.exe", 0x96CC88;
-	ushort bikerFlat:     "HotlineGL.exe", 0x96CCA0;		// not used
+	//ushort bikerFlat:     "HotlineGL.exe", 0x96CCA0;		// not used
 	ushort prankcall :    "HotlineGL.exe", 0x96CC98;
 	ushort resolution :   "HotlineGL.exe", 0x96CCCC;
 	ushort scorescreen :  "HotlineGL.exe", 0x96CB00;
-	ushort gradescreen :  "HotlineGL.exe", 0x9F7728;		//not used		//don't have this for gog//
+	//ushort gradescreen :  "HotlineGL.exe", 0x9F7728;		//not used		//don't have this for gog//
 }
 
 init{
@@ -93,8 +93,6 @@ startup
 	settings.SetToolTip("IL", "*not supported in GoG version* \nThis starts and stops Real Time and stop Game Time on all levels that have score screens. \nTo display IGT, change your active comparison or your layout to game Time.");
 	settings.Add("igt", false, "Display IGT");
 	settings.SetToolTip("igt", "This setting does nothing, but I hereby inform you that the splitter will ALWAYS track IGT, so you can display it during full game runs by adding a timer that displays Game Time (as opposed to Real Time)");
-	settings.Add("death", false, "Track deaths in IGT");
-	settings.SetToolTip("death", "This setting will track how much time you lost to a death or a level restart and add it to your IGT");	
 	
 	// any%
 	vars.split1 = false;
@@ -106,8 +104,6 @@ startup
 	// All Levels
 	vars.startAL = false;
 	vars.afterMetro = false;
-	// track Death
-	vars.deathIGT = 0;
 }
 
 update
@@ -145,18 +141,6 @@ update
 		//	All Levels
 		if (current.room == current.main_menu) {
 			vars.startAL = true;
-			vars.deathIGT = 0;
-		}
-	}
-	
-	//	tracking deaths in gameTime
-	if (settings["death"]) {
-		//	add death to deathIGT
-		if (current.time < old.time) {
-			vars.deathIGT += old.time - current.time;
-		}
-		//	reset deathIGT
-		if (current.time == 0 && old.time != 0 && old.room != current.ig_menu) {
 			vars.deathIGT = 0;
 		}
 	}
@@ -213,7 +197,7 @@ reset
 exit
 {
 	//	Reset on game exit escept during Trauma Skip
-	if (!vars.traumaSkip) {
+	if (!vars.traumaSkip && settings.ResetEnabled) {
 		new TimerModel() { CurrentState = timer }.Reset();
 	}
 }
@@ -312,5 +296,5 @@ isLoading
 
 gameTime
 {
-	return TimeSpan.FromMilliseconds(Convert.ToInt32((current.time+vars.deathIGT)*1000/60));
+	return TimeSpan.FromMilliseconds(Convert.ToInt32((current.time)*1000/60));
 }

--- a/Hotline.asl
+++ b/Hotline.asl
@@ -1,76 +1,284 @@
-state("HotlineGL")
+state("HotlineGL", "steam")
 {
-	int grade :          "HotlineGL.exe", 0x7EC858, 8, 0x5AC, 4, 8;
-	int select_index :   "HotlineGL.exe", 0x7EC858, 8, 0x104, 4, 8;
-	int menu_state :     "HotlineGL.exe", 0x7EC858, 8, 0x10C, 4, 8;
-	int fade :           "HotlineGL.exe", 0x7EC858, 8, 0x11C, 4, 8;
-	int showdown_paper : "HotlineGL.exe", 0xBFFCD8, 0x15CC, 8;
-	double player_x :    "HotlineGL.exe", 0x9F5DC0, 4, 0, 8, 8, 0x50;
-	double bike_climb :  "HotlineGL.exe", 0x9F66F4, 4, 0, 8, 8, 0x98;
+	int select_index :    "HotlineGL.exe", 0x7EC858, 8, 0x104, 4, 8;
+	int menu_state :      "HotlineGL.exe", 0x7EC858, 8, 0x10C, 4, 8;
+	int fade :            "HotlineGL.exe", 0x7EC858, 8, 0x11C, 4, 8;
+	int grade :           "HotlineGL.exe", 0x7EC858, 8, 0x5AC, 4, 8;
+	int showdown_ketchup :"HotlineGL.exe", 0x7EC8B8, 8, 0x7C8, 4, 8;
+	int showdown_paper :  "HotlineGL.exe", 0xBFFCD8, 0x15CC, 8;
+	int time :            "HotlineGL.exe", 0xBFFCD8, 0x98C, 8;
+	double player_x :     "HotlineGL.exe", 0x9F5DC0, 4, 0, 8, 8, 0x50;
+	double bike_climb :   "HotlineGL.exe", 0x9F66F4, 4, 0, 8, 8, 0x98;
 
-	ushort room :        "HotlineGL.exe", 0xBFFC44, 8;
-	ushort menu :        "HotlineGL.exe", 0x9F7534;
-	ushort lvl_select :  "HotlineGL.exe", 0x9F7660;
-	ushort tutorial :    "HotlineGL.exe", 0x9F773C;
-	ushort part :        "HotlineGL.exe", 0x9F75E0;
-	ushort trauma :      "HotlineGL.exe", 0x9F769C;
-	ushort showdown :    "HotlineGL.exe", 0x9F7730;
-	ushort prankcall :   "HotlineGL.exe", 0x9F7740;
-	ushort resolution :  "HotlineGL.exe", 0x9F7774;
-	ushort decadence :   "HotlineGL.exe", 0x9F7584;
-	ushort neighbors :   "HotlineGL.exe", 0x9F7670;
-	ushort deadline :    "HotlineGL.exe", 0x9F75E4;
+	ushort room :         "HotlineGL.exe", 0xBFFC44, 8;
+	ushort zero :		  "HotlineGL,exe", 0x000000;
+	ushort main_menu :    "HotlineGL.exe", 0x9F7534;
+	ushort ig_menu:		  "HotlineGL.exe", 0x9F7640;
+	ushort lvl_select :   "HotlineGL.exe", 0x9F7660;
+	ushort lvl_intro :    "HotlineGL.exe", 0x9F7578;
+	ushort part_screen :  "HotlineGL.exe", 0x9F75E0;
+	ushort grocery_store :"HotlineGL.exe", 0x9F7674;
+	ushort decadence :    "HotlineGL.exe", 0x9F7584;
+	ushort neighbors :    "HotlineGL.exe", 0x9F7670;
+	ushort deadline :     "HotlineGL.exe", 0x9F75E4;
+	ushort trauma_intro : "HotlineGL.exe", 0x9F7700;
+	ushort trauma1:		  "HotlineGL.exe", 0x9F7698;
+	ushort trauma2 :      "HotlineGL.exe", 0x9F769C;
+	ushort trauma_outro : "HotlineGL.exe", 0x9F76FC;
+	ushort assault :      "HotlineGL.exe", 0x9F7600;
+	ushort showdown :     "HotlineGL.exe", 0x9F7730;
+	ushort bikerFlat:     "HotlineGL.exe", 0x9F7748;
+	ushort prankcall :    "HotlineGL.exe", 0x9F7740;
+	ushort resolution :   "HotlineGL.exe", 0x9F7774;
+	ushort scorescreen :  "HotlineGL.exe", 0x9F75A8;
 }
 
-init
+state("HotlineGL", "gog")
 {
-	vars.skip_next = false;
-	vars.split_next = false;
-	vars.start = false;
+	int select_index :    "HotlineGL.exe", 0x761E70, 8, 0x108, 4, 8;
+	int menu_state :      "HotlineGL.exe", 0x761E70, 8, 0x10C, 4, 8;
+	int fade :            "HotlineGL.exe", 0x761E70, 8, 0x11C, 4, 8;
+	int grade :           "HotlineGL.exe", 0x761E70, 8, 0x5A8, 4, 8;
+	int showdown_ketchup :"HotlineGL.exe", 0x761E70, 8, 0x7C8, 4, 8;	//don't work//
+	int showdown_paper :  "HotlineGL.exe", 0x96BB6C, 8;
+	int time :            "HotlineGL.exe", 0x96BB6C, 0x98C, 8;			//don't work//	
+	double player_x :     "HotlineGL.exe", 0x96B330, 4, 0, 8, 8, 0x50;
+	double bike_climb :   "HotlineGL.exe", 0x96BC64, 4, 4, 8, 8, 0x98;
+
+	ushort room :         "HotlineGL.exe", 0xB751C0, 8;
+	ushort zero :		  "HotlineGL,exe", 0x000000;
+	ushort main_menu :    "HotlineGL.exe", 0x96CA8C;
+	ushort ig_menu:		  "HotlineGL.exe", 0x96CB98;
+	ushort lvl_select :   "HotlineGL.exe", 0x96CBB8;
+	ushort lvl_intro :    "HotlineGL.exe", 0x96CAD0;
+	ushort part_screen :  "HotlineGL.exe", 0x96CB38;
+	ushort grocery_store :"HotlineGL.exe", 0x96CBCC;
+	ushort decadence :    "HotlineGL.exe", 0x96CADC;
+	ushort neighbors :    "HotlineGL.exe", 0x96CBC8;
+	ushort deadline :     "HotlineGL.exe", 0x96CB3C;
+	ushort trauma_intro : "HotlineGL.exe", 0x96CC58;
+	ushort trauma1:		  "HotlineGL.exe", 0x96CBF0;
+	ushort trauma2 :      "HotlineGL.exe", 0x96CBF4;
+	ushort trauma_outro : "HotlineGL.exe", 0x96CC54;
+	ushort assault :      "HotlineGL.exe", 0x96CB58;
+	ushort showdown :     "HotlineGL.exe", 0x96CC88;
+	ushort bikerFlat:     "HotlineGL.exe", 0x96CCA0;
+	ushort prankcall :    "HotlineGL.exe", 0x96CC98;
+	ushort resolution :   "HotlineGL.exe", 0x96CCCC;
+	ushort scorescreen :  "HotlineGL.exe", 0x96CB00;	
+}
+
+init{
+	if		(modules.First().ModuleMemorySize == 12718080)	{version = "steam";}
+	else if	(modules.First().ModuleMemorySize == 12140544)	{version = "gog";}
 }
 
 startup
 {
-	settings.Add("e", true,  "End split");
-	settings.SetToolTip("e", "Splits on completion of Resolution");
-	settings.Add("1", true,  "Every Chapter");
-	settings.SetToolTip("1", "Splits after each level (except Resolution)");
-	settings.Add("2", false, "Every Part (All Levels)");
-	settings.SetToolTip("2", "Splits on \"Part X\" screens (except after tutorial)");
-	settings.Add("3", false, "Every Part (Any%)");
-	settings.SetToolTip("3", "Splits after completion of Decadence, Neighbors, Deadline, and Showdown");
+	settings.Add("ssAL", false, "All Levels - Start/Stop");
+	settings.SetToolTip("ssAL", "Just start and end split");
+	settings.Add("buffitAL", false,  "All Levels - Every Level (Buffet) (use this)");
+	settings.SetToolTip("buffitAL", "Splits on every Grade, Trauma doors, Showdown picture, and Prankcall bike");
+	settings.Add("uj_AL", false, "All Levels - Parts (Urin/Jack)");
+	settings.SetToolTip("uj_AL", "Splits after \"Part X\" screens (except part 1)");
+	settings.Add("ssAny", false, "any% - Start/Stop");
+	settings.SetToolTip("ssAny", "Just start and end split");
+	settings.Add("buffitAny", false,  "any% - Every Level (Buffet) (use this)");
+	settings.SetToolTip("buffitAny", "Splits on every Grade, Trauma doors, Showdown picture, and Prankcall bike");
+	settings.Add("u_any", false, "any% - Parts (Urin)");
+	settings.SetToolTip("u_any", "Splits in the intro of Tension, Push It, Trauma and after the Part 5 screen");
+	settings.Add("j_any", false, "any% - Parts (Jack)");
+	settings.SetToolTip("j_any", "Splits in the intro of Tension, Push It, Trauma and before the Part 5 screen");
+	settings.Add("IL", false, "Individual Levels");
+	settings.SetToolTip("IL", "it sorta works - but not withj the GoG version");
+	
+	// any%
+	vars.split1 = false;
+	vars.split2 = false;
+	vars.split3 = false;
+	vars.split4 = false;
+	vars.startAny = false;
+	vars.traumaSkip = false;
+	// All Levels
+	vars.startAL = false;
+	vars.afterMetro = false;
+	// ILs
+	vars.startRoom = 0;
 }
 
 update
 {
-	if (current.room == current.tutorial) vars.skip_next = true;
-	if (current.room == current.decadence || current.room == current.neighbors || current.room == current.deadline) vars.split_next = true;
-	if (old.fade == 0 && current.fade == 1 && current.select_index == 0 && ((current.room == current.menu) ||
-		(current.room == current.lvl_select && current.menu_state == 1))) {vars.start = true; vars.split_next = false;}
+	// any% splits
+	if (current.room > 0 && current.room == current.decadence) 	{vars.split1 = true;}
+	if (current.room > 0 && current.room == current.neighbors) 	{vars.split2 = true;}
+	if (current.room > 0 && current.room == current.deadline) 	{vars.split3 = true;}
+	if (current.room > 0 && current.room == current.showdown) 	{vars.split4 = true;}
+	
+	// Trauma skip
+	if ((settings["u_any"] || settings["j_any"] || settings["buffitAny"] || settings["ssAny"]) && 
+			current.room > 0 && current.room == current.trauma_outro && old.room != current.trauma_outro)	{vars.traumaSkip = true;}
+	if (current.room > 0 && current.room == current.assault && old.room != current.assault) 				{vars.traumaSkip = false;}
+	
+	// after Metro
+	if (current.room == current.grocery_store) {vars.afterMetro = true;}
+	
+	// start variables
+	if (old.fade == 0 && current.fade == 1 && current.select_index == 0 && current.room == current.lvl_select && current.menu_state == 1) 	{vars.startAny = true;} // any%
+	if (old.fade == 0 && current.fade == 1 && current.select_index == 0 && current.room == current.main_menu) 								{vars.startAL = true;}  // All Levels
+	
+	//for debugging
+	//if (old.room != current.room) {print(current.room.ToString());}
+	
+	
 }
 
 start
 {
-	if (vars.start) {
-		vars.start = false;
+	// start All Levels
+		if ((settings["uj_AL"] || settings["ssAL"] || settings["buffitAL"]) && vars.startAL) {
+		vars.startAL = false;
+		vars.afterMetro = false;
+		return true;
+	}
+	// start any%
+	if ((settings["u_any"] || settings["j_any"] || settings["ssAny"] || settings["buffitAny"]) && vars.startAny) {
+		vars.startAny = false;
+		vars.split1 = false;
+		vars.split2 = false;
+		vars.split3 = false;
+		vars.split4 = false;
+		vars.traumaSkip = false;
+		vars.afterMetro = false;
+		return true;
+	}
+	// start ILs
+	if (settings["IL"] && current.time > 0 && current.room != current.trauma1){
+		vars.startRoom = current.room;
+		return true;
+	}
+	//start IL Trauma
+	if (settings["IL"] && current.room == current.trauma1 && old.room != current.trauma1){
 		return true;
 	}
 }
 
-split
+reset
 {
-	if (settings["2"] && old.room != current.part && current.room == current.part) {
-		if (vars.skip_next) vars.skip_next = false;
-		else return true;
-	}
-	// decadence, neighbors, deadline
-	if (settings["3"] && old.grade == 0 && current.grade == 1 && vars.split_next) {
-		vars.split_next = false;
+	// (Alt+F4) on game exit - except during Trauma skip
+	//if (current.room == current.zero && !vars.traumaSkip){
+	//	return true;
+	//}
+	// All Levels / ILs - reset in main menu or on game exit
+	if ((settings["uj_AL"] || settings["ssAL"] || settings["buffitAL"] || settings["IL"] || !vars.afterMetro) && 
+			current.room > 0 && current.room == current.main_menu && old.room != current.main_menu){
 		return true;
 	}
-	return ((settings["1"] && current.room == current.trauma && old.player_x >= -32 && current.player_x < -32) ||                         	// trauma
-		((settings["1"] || settings["3"]) && current.room == current.showdown && old.showdown_paper == 0 && current.showdown_paper == 1) || // showdown
-		(settings["1"] && current.room == current.prankcall && old.bike_climb <= 0.30 && current.bike_climb > 0.30) ||                      // prankcall
-		(current.room == current.resolution && old.bike_climb <= 0.30 && current.bike_climb > 0.30) ||                                      // end split
-		(settings["1"] && old.grade == 0 && current.grade == 1));                                                                           // grade splits
+	// ILs - reset when respawning to the first screen
+	if (settings["IL"] &&
+			current.room == vars.startRoom && current.time == 0){
+		return true;
+	}
+	// ILs - reset on Trauma 1
+	if (settings["IL"] && 
+			current.room == current.trauma1 && old.room != current.trauma1){
+		return true;
+	}
+}
+
+exit
+{
+	//Reset on game exit escept during Trauma Skip
+	if (!vars.traumaSkip){
+		new TimerModel() { CurrentState = timer }.Reset();
+	}
+}
+
+split
+{	
+	// end split
+	if ((current.room == current.resolution && old.bike_climb <= 0.30 && current.bike_climb > 0.30)){
+		return true;
+	}
+	
+	// All Levels Urin/Jack - split Parts
+	if (settings["uj_AL"] &&
+			vars.afterMetro == true && old.room == current.part_screen && current.room != current.part_screen) {
+		return true;
+	}
+	
+	//		any% URIN/JACK		//
+	// split part 1
+	if ((settings["u_any"] || settings["j_any"]) && 
+			(vars.split1 && old.room != current.lvl_intro && current.room == current.lvl_intro)) {
+		vars.split1 = false;
+		return true;
+	}
+	// split part 2
+	if ((settings["u_any"] || settings["j_any"]) && 
+			(vars.split2 && old.room != current.lvl_intro && current.room == current.lvl_intro)) {
+		vars.split2 = false;
+		return true;
+	}
+	// split part 3
+	if ((settings["u_any"] || settings["j_any"]) && 
+			(vars.split3 && old.room != current.trauma_intro && current.room == current.trauma_intro)) {
+		vars.split3 = false;
+		return true;
+	}
+	// Urin - split part 4
+	if (settings["u_any"] && 
+			(vars.split4 && old.room == current.part_screen && current.room != current.part_screen)) {
+		vars.split4 = false;
+		return true;
+	}
+	// Jack - split part 4
+	if (settings["j_any"] && 
+			(vars.split4 && old.room != current.part_screen && current.room == current.part_screen)) {
+		vars.split4 = false;
+		return true;
+	}
+	
+	//		BUFFIT  	//
+	// Grades
+	if ((settings["buffitAL"] || settings["buffitAny"]) &&
+			(old.grade == 0 && current.grade == 1)){
+		return true;
+	}
+	// Trauma door
+	if ((settings["buffitAL"] || settings["buffitAny"]) &&
+			(current.room == current.trauma2 && old.player_x >= -32 && current.player_x < -32)){
+		return true;
+	}
+	// Showdown Photo
+	if ((settings["buffitAL"] || settings["buffitAny"]) &&
+			(current.room == current.showdown && old.showdown_paper == 0 && current.showdown_paper == 1)){
+		return true;
+	}
+	// Prankcall Bike
+	if ((settings["buffitAL"] || settings["buffitAny"]) &&
+			(current.room == current.prankcall && old.bike_climb <= 0.30 && current.bike_climb > 0.30)){
+		return true;
+	}
+	
+	//		INDIVIDUAL LEVELS		//
+	// ILs
+	if (settings["IL"] && 
+			old.room != current.scorescreen && current.room == current.scorescreen){
+		return true;
+	}
+	// IL - Trauma
+	if (settings["IL"] && 
+			old.room == current.trauma2 && current.room != current.trauma2){
+		return true;
+	}
+	// IL - Showdown
+	if (settings["IL"] && 
+			old.room == current.showdown && current.room != current.showdown){
+		return true;
+	}
+	// IL - Prankcall
+	if (settings["IL"] && 
+			old.room != current.bikerFlat && current.room == current.bikerFlat){
+		return true;
+	}
 }

--- a/Hotline.asl
+++ b/Hotline.asl
@@ -11,28 +11,57 @@ state("HotlineGL")
 	ushort room :        "HotlineGL.exe", 0xBFFC44, 8;
 	ushort menu :        "HotlineGL.exe", 0x9F7534;
 	ushort lvl_select :  "HotlineGL.exe", 0x9F7660;
+	ushort tutorial :    "HotlineGL.exe", 0x9F773C;
+	ushort part :        "HotlineGL.exe", 0x9F75E0;
 	ushort trauma :      "HotlineGL.exe", 0x9F769C;
 	ushort showdown :    "HotlineGL.exe", 0x9F7730;
 	ushort prankcall :   "HotlineGL.exe", 0x9F7740;
 	ushort resolution :  "HotlineGL.exe", 0x9F7774;
 }
 
+init
+{
+	vars.skip_next = false;
+	vars.counter = 0;
+}
+
 startup
 {
-	settings.Add("o", false, "Only End split");
-	settings.SetToolTip("o", "Remove all splits except the final one - Resolution");
+	settings.Add("e", true,  "End split");
+	settings.SetToolTip("e", "Resolution");
+	settings.Add("1", true,  "Every Chapter");
+	settings.SetToolTip("1", "Splits on grade screen, trauma room exit, showdown and prank call");
+	settings.Add("2", false, "Every Part (All Levels)");
+	settings.SetToolTip("2", "Splits on \"Part X\" screens (except after tutorial)");
+	settings.Add("3", false, "Every Part (Any%)");
+	settings.SetToolTip("3", "Splits after Decadence, Neighbors, Deadline and Showdown");
+}
+
+update
+{
+	if (current.room == current.tutorial) vars.skip_next = true;
+	if (old.grade == 0 && current.grade == 1) vars.counter++;
 }
 
 start
 {
-	return (old.fade == 0 && current.fade == 1 && current.select_index == 0 &&
-	       ((current.room == current.menu) || (current.room == current.lvl_select && current.menu_state == 1)));
+	if (old.fade == 0 && current.fade == 1 && current.select_index == 0 &&
+	((current.room == current.menu) || (current.room == current.lvl_select && current.menu_state == 1))) {
+		vars.counter = 0;
+		return true;
+	}
 }
 
 split
 {
-	return ((!settings["o"] && current.room == current.trauma && old.player_x >= -32 && current.player_x < -32) || // trauma
-		(!settings["o"] && current.room == current.showdown && old.showdown_paper == 0 && current.showdown_paper == 1) || // showdown
-		(((!settings["o"] && current.room == current.prankcall) || (current.room == current.resolution)) && old.bike_climb <= 0.30 && current.bike_climb > 0.30) ||
-		(!settings["o"] && old.grade == 0 && current.grade == 1));
+	if (settings["2"] && old.room != current.part && current.room == current.part) {
+		if (vars.skip_next) vars.skip_next = false;
+		else return true;
+	}
+	return ((settings["1"] && current.room == current.trauma && old.player_x >= -32 && current.player_x < -32) ||                         	// trauma
+		((settings["1"] || settings["3"]) && current.room == current.showdown && old.showdown_paper == 0 && current.showdown_paper == 1) || // showdown
+		(settings["1"] && current.room == current.prankcall && old.bike_climb <= 0.30 && current.bike_climb > 0.30) ||                      // prankcall
+		(current.room == current.resolution && old.bike_climb <= 0.30 && current.bike_climb > 0.30) ||                                      // end split
+		(settings["1"] && old.grade == 0 && current.grade == 1) ||                                                                          // grade splits
+		(settings["3"] && old.grade == 0 && current.grade == 1 && (vars.counter == 4 || vars.counter == 8 || vars.counter == 12)));         // decadence, neighbors, deadline
 }


### PR DESCRIPTION
- fixed a bug where death tracking on Biker levels in gog version did not work (added biker_dead variable for this)
- changed the version recognition method from ModuleMemorySize to Hash, because version recognition for gog version rarely and randomly failed
- removed setting "any% - parts (Urin) "any% - Parts (Jack)" has become simply "any% - Parts"
- added startRoom variable to IL splitting so the splitter only starts on levels with intro screen, not in the menu or wherever else